### PR TITLE
chore: update the setup-go ci action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-          cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -19,10 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-          cache: true
       - run: go test -cover
       - run: go test -race
       - run: go vet


### PR DESCRIPTION
`cache` is enabled by default in the new version